### PR TITLE
patch

### DIFF
--- a/node/pkg/tss/fault_tolerance.go
+++ b/node/pkg/tss/fault_tolerance.go
@@ -50,8 +50,9 @@ import (
 //     it has about the digest.
 //   - deliveryCommand is used to inform the ftTracker that a guardian saw a message and forwarded it
 //     to the fullParty.
-//   - prepareToSignCommand is used to know which guardians aren't to be used in the protocol for
-//     specific chainID.
+//   - prepareToSignCommand is used prior to trying to sign a digest.
+//     it provides the current state of the FTtracker's knowledge (faults for specific ChainID),
+//     and whether a digest has already been requested to be signed.
 //   - reportProblemCommand is used to deliver a problem message from another
 //     guardian (after it was accepted by the reliable-broadcast protocol).
 type ftCommand interface {

--- a/node/pkg/tss/implementation.go
+++ b/node/pkg/tss/implementation.go
@@ -234,10 +234,6 @@ func (t *Engine) beginTSSSign(vaaDigest []byte, chainID vaa.ChainID, isRetry boo
 		return fmt.Errorf("vaaDigest length is not 32 bytes")
 	}
 
-	if chainID == vaa.ChainIDPythNet {
-		return nil // TODO: Remove this.
-	}
-
 	t.logger.Info("signature for VAA requested",
 		zap.String("digest", fmt.Sprintf("%x", vaaDigest)),
 		zap.String("chainID", chainID.String()),

--- a/node/pkg/tss/util.go
+++ b/node/pkg/tss/util.go
@@ -136,6 +136,7 @@ func logErr(l *zap.Logger, err error) {
 	var zapFields []zap.Field
 	if informativeErr.trackingId != nil {
 		zapFields = append(zapFields, zap.String("trackingId", informativeErr.trackingId.ToString()))
+		zapFields = append(zapFields, zap.String("chainID", extractChainIDFromTrackingID(informativeErr.trackingId).String()))
 	}
 
 	if informativeErr.round != "" {


### PR DESCRIPTION
- Adding bool memory to check which `trackingID` was sent to `beginTSSSign` or not. 
- Adding timestamps to equivocation error logs.
- Improved error logs: prints the chainID too.
